### PR TITLE
Fix: #14: Bump isort to support py3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
     -   id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)


### PR DESCRIPTION
Upgrading isort version on pre-commit config file will allow the user to install pre-commit on an environment running Python 3.11.

As per iSort's changelog
https://github.com/PyCQA/isort/blob/main/CHANGELOG.md
They fixed incompatibilities with poetry, 

One caveat: python3.7 support has been removed in version 5.12.0 .

@ioggstream