### PR TITLE
Fix: #36. Prefer black formatting over flake8.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,12 +31,6 @@ setenv =
 commands =
   safety check --short-report -r requirements.txt
 
-[flake8]
-# Ignore long lines in flake8 because
-#   they are managed by black and we
-#   want to support links.
-max-line-length = 150
-
 [testenv:release]
 # Release with tox via:
 #
@@ -68,3 +62,14 @@ commands =
 # [testenv:test-release]
 #commands =
 #  pip install --index-url=https://test.pypi.org/simple
+
+#
+# Tools configuration.
+#
+[flake8]
+# Ignore long lines in flake8 because
+#   they are managed by black and we
+#   want to support links.
+max-line-length = 150
+# Disable E203 because black correctly handles whitespaces before ':'.
+extend-ignore = E203


### PR DESCRIPTION
## This PR

- prefers black formatting over flake8

## It is done

- disabling E203 check.

see #36 